### PR TITLE
docs: minor updates

### DIFF
--- a/uhi/typing/plottable.py
+++ b/uhi/typing/plottable.py
@@ -102,8 +102,8 @@ class PlottableHistogram(Protocol):
         undefined and left up to the Producer implementation if counts is less
         than 1. A Consumer should check counts before using this.
 
-        All methods can have a flow=False argument - not part of Protocol.  If
-        this is included, it should return an array with flow bins added,
+        All methods can have a flow=False argument - not part of this Protocol.
+        If this is included, it should return an array with flow bins added,
         normal ordering.
         """
 
@@ -117,11 +117,12 @@ class PlottableHistogram(Protocol):
         kind=="MEAN".
         """
 
-    def counts(self) -> Optional[ArrayLike]:
+    def effective_counts(self) -> Optional[ArrayLike]:
         """
-        Count returns the effective number of entries. Current Kinds of common histograms
-        all have a defined counts, but an exotic histogram could have a None .counts, so
-        this is Optional and should be checked by Consumers.
+        Count returns the effective number of entries in each bin. Current Kinds
+        of common histograms all have a defined counts, but an exotic histogram
+        could have a None .counts, so this is Optional and should be checked by
+        Consumers.
 
         For a weighted histogram, counts is defined as sum_of_weights ** 2 /
         sum_of_weights_squared. It is always equal to or smaller than the
@@ -136,5 +137,5 @@ class PlottableHistogram(Protocol):
                 sum_of_weights**2,
                 sum_of_weights_squared,
                 out=np.zeros_like(sum_of_weights, dtype=np.float64),
-                where=sum_of_weights_squared!=0)
+                where=sum_of_weights_squared != 0)
         """

--- a/uhi/typing/plottable.py
+++ b/uhi/typing/plottable.py
@@ -117,7 +117,7 @@ class PlottableHistogram(Protocol):
         kind=="MEAN".
         """
 
-    def effective_counts(self) -> Optional[ArrayLike]:
+    def counts(self) -> Optional[ArrayLike]:
         """
         Count returns the effective number of entries in each bin. Current Kinds
         of common histograms all have a defined counts, but an exotic histogram


### PR DESCRIPTION
This is a followup to #2, with one more possible change. This is a bit of extra typing, but is much clearer; I could see the following to be rather confusing if this is named `counts` instead of `effective_counts`, since it's not always the true number of counts, but an effective count calculation. For a user filling a weighed sum or weighed mean histogram, the fact that ".counts" is neither the number of times filled nor the weighted number of times filled is likely to be quite a surprise. While if it was called "effective_counts", they would be more likely to suspect that it's a special computed quantity and not just the raw or weighted counts.

Followup to #2, CC @HDembinski and @JPivarski.